### PR TITLE
add `contain-nested` option for external mixins

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,7 +3,7 @@
     "./index.js"
   ],
   "rules": {
-    "@apostrophecms/stylelint-no-mixed-decls":[
+    "@apostrophecms/stylelint-no-mixed-decls": [
       true,
       {
         "contain-nested": [ "external-mixin-known-to-contain-nested-rules" ]

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,6 +3,11 @@
     "./index.js"
   ],
   "rules": {
-    "@apostrophecms/stylelint-no-mixed-decls": true
+    "@apostrophecms/stylelint-no-mixed-decls":[
+      true,
+      {
+        "contain-nested": [ "external-mixin-known-to-contain-nested-rules" ]
+      }
+    ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Adds
+
+* New `contain-nested` array option to list mixins that are known to contain nested rules.
+
 ## 1.1.0
 
 ### Adds

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This is an answer to the [limitations](#limitations) that this plugin cannot ana
 
 .foo {
   @include foo;
-  @include external-mixin // not known to contain nested rules
+  @include external-mixin; // not known to contain nested rules
   color: red;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -198,10 +198,11 @@ or colocate them with the code that uses them.
 Alternatively, wrap declarations following `@include` statements
 in a nested `& { }` block as a safe default when unsure of the mixin's contents.
 
-**`contain-nested` option**
+**Use `contain-nested` option:**
 
 This option can be used to list mixins that are known to contain nested rules,
-so that the plugin can treat them accordingly.
+so that the plugin can treat them accordingly,
+even if their definition is not present in the file they are used.
 
 ## Please contribute!
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ Add it to your Stylelint configuration:
 }
 ```
 
+You can set a `contain-nested` option to list mixins that are known to contain nested rules.  
+This is an answer to the [limitations](#limitations) that this plugin cannot analyze mixin definitions from other files.
+
+```js
+{
+  "plugins": [ "@apostrophecms/stylelint-no-mixed-decls" ],
+  "rules": {
+    "@apostrophecms/stylelint-no-mixed-decls": [
+      true,
+      {
+        "contain-nested": [ "external-mixin-known-to-contain-nested-rules" ]
+      }
+    ] 
+  }
+}
+```
+
 ## Example: Correct Usage
 
 ```scss
@@ -55,6 +72,7 @@ Add it to your Stylelint configuration:
 
 .foo {
   @include foo;
+  @include external-mixin // not known to contain nested rules
   color: red;
 }
 ```
@@ -144,6 +162,14 @@ Add it to your Stylelint configuration:
 }
 ```
 
+```scss
+.foo {
+  @include external-mixin-known-to-contain-nested-rules;
+
+  color: red; // ❌ Cannot mix declarations and nested rules. Group them together or wrap declarations in a nested "& { }" block. See https://sass-lang.com/documentation/breaking-changes/mixed-decls/
+}
+```
+
 ## Why this matters
 
 This plugin ensures your Sass code adheres to modern CSS nesting behavior,
@@ -171,6 +197,11 @@ To ensure accurate linting results, define critical mixins with nested rules con
 or colocate them with the code that uses them.
 Alternatively, wrap declarations following `@include` statements
 in a nested `& { }` block as a safe default when unsure of the mixin's contents.
+
+**`contain-nested` option**
+
+This option can be used to list mixins that are known to contain nested rules,
+so that the plugin can treat them accordingly.
 
 ## Please contribute!
 

--- a/test/bad.scss
+++ b/test/bad.scss
@@ -71,3 +71,11 @@
   @include flat-2;
   @include mixed-2;
 }
+
+// This is bad because the mixin is known to contain nested rules,
+// therefore the rule that comes after it should be wrapped.
+.d {
+  @include external-mixin-known-to-contain-nested-rules;
+
+  color: red;
+}

--- a/test/good.scss
+++ b/test/good.scss
@@ -110,3 +110,24 @@
 
   color: red;
 }
+
+// This is okay because the mixin isn't known to contain nested rules.
+.m {
+  @include external-mixin;
+
+  color: red;
+}
+
+// This is okay because nothings comes after the mixin.
+.n {
+  @include external-mixin-known-to-contain-nested-rules;
+}
+
+// This is okay because the rule that comes after the mixin is wrapped.
+.o {
+  @include external-mixin-known-to-contain-nested-rules;
+
+  & {
+    color: red;
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -18,13 +18,11 @@ describe('@apostrophecms/stylelint-no-mixed-decls stylelint rule', function() {
       throw new Error(`Unexpected output: ${stdout}`);
     }
 
-    const expectedOccurrences = 12;
-    const occurrences = countOccurences(ERROR_MESSAGE, stderr);
-
     const expectedErrorPositions = [
       [ 7, 3 ],
       [ 8, 3 ],
       [ 29, 3 ],
+      [ 30, 3 ],
       [ 34, 3 ],
       [ 35, 3 ],
       [ 45, 3 ],
@@ -32,21 +30,26 @@ describe('@apostrophecms/stylelint-no-mixed-decls stylelint rule', function() {
       [ 56, 3 ],
       [ 57, 3 ],
       [ 64, 3 ],
-      [ 70, 3 ]
+      [ 70, 3 ],
+      [ 78, 3 ]
     ];
+    const expectedErrorOccurrences = expectedErrorPositions.length;
+    const actualErrorOccurrences = countOccurences(ERROR_MESSAGE, stderr);
+
+    const errorPositionsMessages = expectedErrorPositions
+      .map(position =>
+        !stderr.includes(position.join(':')) &&
+        `Expected error message to include line ${position.join(':')} but it did not`
+      )
+      .filter(Boolean);
 
     assert.strictEqual(
-      occurrences,
-      expectedOccurrences,
-      `Expected 12 occurrences of "${ERROR_MESSAGE}" but found ${occurrences}`
-    );
+      actualErrorOccurrences,
+      expectedErrorOccurrences,
+      `Expected ${expectedErrorOccurrences} occurrences of "${ERROR_MESSAGE}" but found ${actualErrorOccurrences}.
 
-    expectedErrorPositions.forEach(position => {
-      assert.ok(
-        stderr.includes(position.join(':')),
-        `Expected error message to include line ${position.join(':')} but it did not`
-      );
-    });
+${errorPositionsMessages.join('\n')}`
+    );
   });
 
   it('should pass when css contains nested rules and scoped declarations', async function() {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- [x] update tests
- [x] update readme 👉  https://github.com/apostrophecms/stylelint-no-mixed-decls/blob/add-option/README.md

Adds a new `contain-nested` option for external mixins known to contain nested rules.
This answers the limitation of the plugin not being able to see mixin definitions from other files.

See https://github.com/apostrophecms/apostrophe/pull/5042